### PR TITLE
ログ出力内容にcontrollerとactionを追加

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,8 +80,22 @@ Rails.application.configure do
     end
   end
 
-  config.logger = ActiveSupport::Logger.new(STDOUT)
-  config.logger.formatter = CustomLogFormatter.new
+  # ログファイルへの出力設定
+  log_file = File.open(Rails.root.join("log", "#{Rails.env}.log"), "a")
+  log_file.sync = true
+  file_logger = ActiveSupport::Logger.new(log_file)
+  file_logger.formatter = CustomLogFormatter.new
+
+  # STDOUT への出力設定
+  stdout_logger = ActiveSupport::Logger.new(STDOUT)
+  stdout_logger.formatter = CustomLogFormatter.new
+
+  # 両方に出力するロガーを作成
+  combined_logger = ActiveSupport::Logger.new(STDOUT)
+  combined_logger.extend(ActiveSupport::Logger.broadcast(file_logger))
+  combined_logger.formatter = CustomLogFormatter.new
+
+  config.logger = combined_logger
 
   # リクエストごとに controller, action を記録
   ActiveSupport::Notifications.subscribe("start_processing.action_controller") do |*args|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,48 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # 既存のログフォーマッターを使用
+  config.log_formatter = ::Logger::Formatter.new
+
+  # ログに controller と action を追加
+  class CustomLogFormatter < Logger::Formatter
+    def call(severity, timestamp, progname, msg)
+      request_info = Thread.current[:log_request_info] || {}
+      controller_action = request_info[:controller] && request_info[:action] ? "[#{request_info[:controller]}##{request_info[:action]}]" : ""
+      "#{timestamp.iso8601} [#{severity}] #{controller_action} #{msg}\n"
+    end
+  end
+
+  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger.formatter = CustomLogFormatter.new
+
+  # リクエストごとに controller, action を記録
+  ActiveSupport::Notifications.subscribe("start_processing.action_controller") do |*args|
+    event = ActiveSupport::Notifications::Event.new(*args)
+    payload = event.payload
+    Thread.current[:log_request_info] = {
+      controller: payload[:controller],
+      action: payload[:action]
+    }
+  end
+
+  # `process_action.action_controller` では情報をクリアしない
+  # リクエスト終了後にクリアする
+  config.middleware.insert_after ActionDispatch::Executor, Middleware::ClearLogRequestInfo if defined?(Middleware::ClearLogRequestInfo)
+end
+
+# ミドルウェアを定義（リクエスト終了後にクリア）
+module Middleware
+  class ClearLogRequestInfo
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+    ensure
+      Thread.current[:log_request_info] = nil
+    end
+  end
 end


### PR DESCRIPTION
ログ出力内容にcontrollerとactionを追加

ためしようなので、CustomLogFormatterはdevelopment環境でだけ追加

以下のようなログが出るようになりました
```
2025-07-31T11:11:20+09:00 [INFO]  Started GET "/animals/51" for ::1 at 2025-07-31 11:11:20 +0900
2025-07-31T11:11:20+09:00 [DEBUG]    [1m[36mActiveRecord::SchemaMigration Pluck (0.1ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
2025-07-31T11:11:20+09:00 [INFO] [AnimalsController#show] Processing by AnimalsController#show as HTML
2025-07-31T11:11:20+09:00 [INFO] [AnimalsController#show]   Parameters: {"id"=>"51"}
2025-07-31T11:11:20+09:00 [DEBUG] [AnimalsController#show]   [1m[36mAnimal Load (0.3ms)[0m  
：
2025-07-31T11:11:20+09:00 [INFO] [AnimalsController#show]   Rendered layout layouts/application.html.erb (Duration: 37.7ms | Allocations: 40072)
2025-07-31T11:11:20+09:00 [INFO] [AnimalsController#show] Completed 200 OK in 56ms (Views: 40.3ms | ActiveRecord: 0.5ms | Allocations: 52775)

```